### PR TITLE
INT-445 Updated [nexus-iq-server][config] structure for NXIQ-1.43+

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,43 +13,4 @@ default['nexus_iq_server']['install_dir'] = '/opt/sonatype/nexus-iq-server'
 default['nexus_iq_server']['logs_dir'] = '/var/log/nexus-iq-server'
 default['nexus_iq_server']['conf_dir'] = '/etc/nexus-iq-server'
 default['nexus_iq_server']['java_opts'] = ''
-
-#
-# default['nexus_iq_server']['config'] is used to generate config.yml. Parameter names and hierarchy must be the same as they
-# are in config.yml.
-#
-default['nexus_iq_server']['config']['sonatypeWork'] = default['nexus_iq_server']['install_dir'] + '/sonatype-work/'
-default['nexus_iq_server']['config']['server']['applicationConnectors'] = [{'type' => 'http', 'port' => 8070}]
-default['nexus_iq_server']['config']['server']['adminConnectors'] = [{'type' => 'http', 'port' => 8071}]
-default['nexus_iq_server']['config']['server']['requestLog']['appenders'] = [
-  {
-    'type' => 'file',
-    'currentLogFilename' => default['nexus_iq_server']['logs_dir'] + '/request.log',
-    'archivedLogFilenamePattern' => default['nexus_iq_server']['logs_dir'] + "/request-\%d.log.gz",
-    'archivedFileCount' => 50
-  }
-]
-default['nexus_iq_server']['config']['logging']['level'] = 'DEBUG'
-default['nexus_iq_server']['config']['logging']['loggers']['com.sonatype.insight.scan'] = 'INFO'
-default['nexus_iq_server']['config']['logging']['loggers']['eu.medsea.mimeutil.MimeUtil2'] = 'INFO'
-default['nexus_iq_server']['config']['logging']['loggers']['org.apache.http'] = 'INFO'
-default['nexus_iq_server']['config']['logging']['loggers']['org.apache.http.wire'] = 'ERROR'
-default['nexus_iq_server']['config']['logging']['loggers']['org.eclipse.birt.report.engine.layout.pdf.font.FontConfigReader'] = 'WARN'
-default['nexus_iq_server']['config']['logging']['loggers']['org.eclipse.jetty'] = 'INFO'
-# WARNING: BasicHttpAuthenticationFilter reveals credentials at DEBUG level
-default['nexus_iq_server']['config']['logging']['loggers']['org.apache.shiro.web.filter.authc.BasicHttpAuthenticationFilter'] = 'INFO'
-default['nexus_iq_server']['config']['logging']['appenders'] = [
-  {
-    'type' => 'console',
-    'threshold' => 'INFO',
-    'logFormat' => "%d{'yyyy-MM-dd HH:mm:ss,SSSZ'} %level [%thread] %X{username} %logger - %msg%n"
-  },
-  {
-    'type' => 'file',
-    'threshold' => 'ALL',
-    'currentLogFilename' => "/var/log/nexus-iq-server/clm-server.log",
-    'archivedLogFilenamePattern' => "/var/log/nexus-iq-server/clm-server-%d.log.gz",
-    'logFormat' => "%d{'yyyy-MM-dd HH:mm:ss,SSSZ'} %level [%thread] %X{username} %logger - %msg%n",
-    'archivedFileCount' => 50
-  }
-]
+default['nexus_iq_server']['logging']['archived_file_count'] = 50

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,13 +19,16 @@ default['nexus_iq_server']['java_opts'] = ''
 # are in config.yml.
 #
 default['nexus_iq_server']['config']['sonatypeWork'] = default['nexus_iq_server']['install_dir'] + '/sonatype-work/'
-default['nexus_iq_server']['config']['http']['port'] = 8070
-default['nexus_iq_server']['config']['http']['adminPort'] = 8071
-default['nexus_iq_server']['config']['http']['requestLog']['console']['enabled'] = false
-default['nexus_iq_server']['config']['http']['requestLog']['file']['enabled'] = true
-default['nexus_iq_server']['config']['http']['requestLog']['file']['currentLogFilename'] = default['nexus_iq_server']['logs_dir'] + '/request.log'
-default['nexus_iq_server']['config']['http']['requestLog']['file']['archivedLogFilenamePattern'] = default['nexus_iq_server']['logs_dir'] + "/request-\%d.log.gz"
-default['nexus_iq_server']['config']['http']['requestLog']['file']['archivedFileCount'] = 50
+default['nexus_iq_server']['config']['server']['applicationConnectors'] = [{'type' => 'http', 'port' => 8070}]
+default['nexus_iq_server']['config']['server']['adminConnectors'] = [{'type' => 'http', 'port' => 8071}]
+default['nexus_iq_server']['config']['server']['requestLog']['appenders'] = [
+  {
+    'type' => 'file',
+    'currentLogFilename' => default['nexus_iq_server']['logs_dir'] + '/request.log',
+    'archivedLogFilenamePattern' => default['nexus_iq_server']['logs_dir'] + "/request-\%d.log.gz",
+    'archivedFileCount' => 50
+  }
+]
 default['nexus_iq_server']['config']['logging']['level'] = 'DEBUG'
 default['nexus_iq_server']['config']['logging']['loggers']['com.sonatype.insight.scan'] = 'INFO'
 default['nexus_iq_server']['config']['logging']['loggers']['eu.medsea.mimeutil.MimeUtil2'] = 'INFO'
@@ -35,12 +38,18 @@ default['nexus_iq_server']['config']['logging']['loggers']['org.eclipse.birt.rep
 default['nexus_iq_server']['config']['logging']['loggers']['org.eclipse.jetty'] = 'INFO'
 # WARNING: BasicHttpAuthenticationFilter reveals credentials at DEBUG level
 default['nexus_iq_server']['config']['logging']['loggers']['org.apache.shiro.web.filter.authc.BasicHttpAuthenticationFilter'] = 'INFO'
-default['nexus_iq_server']['config']['logging']['console']['enabled'] = true
-default['nexus_iq_server']['config']['logging']['console']['threshold'] = 'INFO'
-default['nexus_iq_server']['config']['logging']['console']['logFormat'] = "\%d{'yyyy-MM-dd HH:mm:ss,SSSZ'} \%level [\%thread] \%X{username} \%logger \%msg\%n"
-default['nexus_iq_server']['config']['logging']['file']['enabled'] = true
-default['nexus_iq_server']['config']['logging']['file']['threshold'] = 'ALL'
-default['nexus_iq_server']['config']['logging']['file']['currentLogFilename'] = default['nexus_iq_server']['logs_dir'] + '/clm-server.log'
-default['nexus_iq_server']['config']['logging']['file']['archivedLogFilenamePattern'] = default['nexus_iq_server']['logs_dir'] + "/clm-server-\%d.log.gz"
-default['nexus_iq_server']['config']['logging']['file']['archivedFileCount'] = 50
-default['nexus_iq_server']['config']['logging']['file']['logFormat'] = "\%d{'yyyy-MM-dd HH:mm:ss,SSSZ'} \%level [\%thread] \%X{username} \%logger \%msg\%n"
+default['nexus_iq_server']['config']['logging']['appenders'] = [
+  {
+    'type' => 'console',
+    'threshold' => 'INFO',
+    'logFormat' => "%d{'yyyy-MM-dd HH:mm:ss,SSSZ'} %level [%thread] %X{username} %logger - %msg%n"
+  },
+  {
+    'type' => 'file',
+    'threshold' => 'ALL',
+    'currentLogFilename' => "/var/log/nexus-iq-server/clm-server.log",
+    'archivedLogFilenamePattern' => "/var/log/nexus-iq-server/clm-server-%d.log.gz",
+    'logFormat' => "%d{'yyyy-MM-dd HH:mm:ss,SSSZ'} %level [%thread] %X{username} %logger - %msg%n",
+    'archivedFileCount' => 50
+  }
+]

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,4 +13,43 @@ default['nexus_iq_server']['install_dir'] = '/opt/sonatype/nexus-iq-server'
 default['nexus_iq_server']['logs_dir'] = '/var/log/nexus-iq-server'
 default['nexus_iq_server']['conf_dir'] = '/etc/nexus-iq-server'
 default['nexus_iq_server']['java_opts'] = ''
-default['nexus_iq_server']['logging']['archived_file_count'] = 50
+
+#
+# default['nexus_iq_server']['config'] is used to generate config.yml. Parameter names and hierarchy must be the same as they
+# are in config.yml.
+#
+default['nexus_iq_server']['config']['sonatypeWork'] = node['nexus_iq_server']['install_dir'] + '/sonatype-work/'
+default['nexus_iq_server']['config']['server']['applicationConnectors'] = [{'type' => 'http', 'port' => 8070}]
+default['nexus_iq_server']['config']['server']['adminConnectors'] = [{'type' => 'http', 'port' => 8071}]
+default['nexus_iq_server']['config']['server']['requestLog']['appenders'] = [
+  {
+    'type' => 'file',
+    'currentLogFilename' => node['nexus_iq_server']['logs_dir'] + '/request.log',
+    'archivedLogFilenamePattern' => node['nexus_iq_server']['logs_dir'] + "/request-\%d.log.gz",
+    'archivedFileCount' => 50
+  }
+]
+default['nexus_iq_server']['config']['logging']['level'] = 'DEBUG'
+default['nexus_iq_server']['config']['logging']['loggers']['com.sonatype.insight.scan'] = 'INFO'
+default['nexus_iq_server']['config']['logging']['loggers']['eu.medsea.mimeutil.MimeUtil2'] = 'INFO'
+default['nexus_iq_server']['config']['logging']['loggers']['org.apache.http'] = 'INFO'
+default['nexus_iq_server']['config']['logging']['loggers']['org.apache.http.wire'] = 'ERROR'
+default['nexus_iq_server']['config']['logging']['loggers']['org.eclipse.birt.report.engine.layout.pdf.font.FontConfigReader'] = 'WARN'
+default['nexus_iq_server']['config']['logging']['loggers']['org.eclipse.jetty'] = 'INFO'
+# WARNING: BasicHttpAuthenticationFilter reveals credentials at DEBUG level
+default['nexus_iq_server']['config']['logging']['loggers']['org.apache.shiro.web.filter.authc.BasicHttpAuthenticationFilter'] = 'INFO'
+default['nexus_iq_server']['config']['logging']['appenders'] = [
+  {
+    'type' => 'console',
+    'threshold' => 'INFO',
+    'logFormat' => "%d{'yyyy-MM-dd HH:mm:ss,SSSZ'} %level [%thread] %X{username} %logger - %msg%n"
+  },
+  {
+    'type' => 'file',
+    'threshold' => 'ALL',
+    'currentLogFilename' => "/var/log/nexus-iq-server/clm-server.log",
+    'archivedLogFilenamePattern' => "/var/log/nexus-iq-server/clm-server-%d.log.gz",
+    'logFormat' => "%d{'yyyy-MM-dd HH:mm:ss,SSSZ'} %level [%thread] %X{username} %logger - %msg%n",
+    'archivedFileCount' => 50
+  }
+]

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -4,46 +4,6 @@
 #
 # Copyright:: Copyright (c) 2017-present Sonatype, Inc. Apache License, Version 2.0.
 
-#
-# default['nexus_iq_server']['config'] is used to generate config.yml. Parameter names and hierarchy must be the same as they
-# are in config.yml.
-#
-node.default['nexus_iq_server']['config']['sonatypeWork'] = node['nexus_iq_server']['install_dir'] + '/sonatype-work/'
-node.default['nexus_iq_server']['config']['server']['applicationConnectors'] = [{'type' => 'http', 'port' => 8070}]
-node.default['nexus_iq_server']['config']['server']['adminConnectors'] = [{'type' => 'http', 'port' => 8071}]
-node.default['nexus_iq_server']['config']['server']['requestLog']['appenders'] = [
-  {
-    'type' => 'file',
-    'currentLogFilename' => node['nexus_iq_server']['logs_dir'] + '/request.log',
-    'archivedLogFilenamePattern' => node['nexus_iq_server']['logs_dir'] + "/request-\%d.log.gz",
-    'archivedFileCount' => node['nexus_iq_server']['logging']['archived_file_count']
-  }
-]
-node.default['nexus_iq_server']['config']['logging']['level'] = 'DEBUG'
-node.default['nexus_iq_server']['config']['logging']['loggers']['com.sonatype.insight.scan'] = 'INFO'
-node.default['nexus_iq_server']['config']['logging']['loggers']['eu.medsea.mimeutil.MimeUtil2'] = 'INFO'
-node.default['nexus_iq_server']['config']['logging']['loggers']['org.apache.http'] = 'INFO'
-node.default['nexus_iq_server']['config']['logging']['loggers']['org.apache.http.wire'] = 'ERROR'
-node.default['nexus_iq_server']['config']['logging']['loggers']['org.eclipse.birt.report.engine.layout.pdf.font.FontConfigReader'] = 'WARN'
-node.default['nexus_iq_server']['config']['logging']['loggers']['org.eclipse.jetty'] = 'INFO'
-# WARNING: BasicHttpAuthenticationFilter reveals credentials at DEBUG level
-node.default['nexus_iq_server']['config']['logging']['loggers']['org.apache.shiro.web.filter.authc.BasicHttpAuthenticationFilter'] = 'INFO'
-node.default['nexus_iq_server']['config']['logging']['appenders'] = [
-  {
-    'type' => 'console',
-    'threshold' => 'INFO',
-    'logFormat' => "%d{'yyyy-MM-dd HH:mm:ss,SSSZ'} %level [%thread] %X{username} %logger - %msg%n"
-  },
-  {
-    'type' => 'file',
-    'threshold' => 'ALL',
-    'currentLogFilename' => "/var/log/nexus-iq-server/clm-server.log",
-    'archivedLogFilenamePattern' => "/var/log/nexus-iq-server/clm-server-%d.log.gz",
-    'logFormat' => "%d{'yyyy-MM-dd HH:mm:ss,SSSZ'} %level [%thread] %X{username} %logger - %msg%n",
-    'archivedFileCount' => node['nexus_iq_server']['logging']['archived_file_count']
-  }
-]
-
 config_path = node['nexus_iq_server']['conf_dir'] + '/config.yml'
 start_script = node['nexus_iq_server']['install_dir'] + '/start-nexus-iq-server.sh'
 
@@ -70,8 +30,6 @@ directory node['nexus_iq_server']['config']['sonatypeWork'] do
   action :create
   recursive true
 end
-
-node.override['nexus_iq_server']['logging']['archived_file_count'] = 5
 
 template config_path do
   source 'config.yml.erb'

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -4,6 +4,46 @@
 #
 # Copyright:: Copyright (c) 2017-present Sonatype, Inc. Apache License, Version 2.0.
 
+#
+# default['nexus_iq_server']['config'] is used to generate config.yml. Parameter names and hierarchy must be the same as they
+# are in config.yml.
+#
+node.default['nexus_iq_server']['config']['sonatypeWork'] = node['nexus_iq_server']['install_dir'] + '/sonatype-work/'
+node.default['nexus_iq_server']['config']['server']['applicationConnectors'] = [{'type' => 'http', 'port' => 8070}]
+node.default['nexus_iq_server']['config']['server']['adminConnectors'] = [{'type' => 'http', 'port' => 8071}]
+node.default['nexus_iq_server']['config']['server']['requestLog']['appenders'] = [
+  {
+    'type' => 'file',
+    'currentLogFilename' => node['nexus_iq_server']['logs_dir'] + '/request.log',
+    'archivedLogFilenamePattern' => node['nexus_iq_server']['logs_dir'] + "/request-\%d.log.gz",
+    'archivedFileCount' => node['nexus_iq_server']['logging']['archived_file_count']
+  }
+]
+node.default['nexus_iq_server']['config']['logging']['level'] = 'DEBUG'
+node.default['nexus_iq_server']['config']['logging']['loggers']['com.sonatype.insight.scan'] = 'INFO'
+node.default['nexus_iq_server']['config']['logging']['loggers']['eu.medsea.mimeutil.MimeUtil2'] = 'INFO'
+node.default['nexus_iq_server']['config']['logging']['loggers']['org.apache.http'] = 'INFO'
+node.default['nexus_iq_server']['config']['logging']['loggers']['org.apache.http.wire'] = 'ERROR'
+node.default['nexus_iq_server']['config']['logging']['loggers']['org.eclipse.birt.report.engine.layout.pdf.font.FontConfigReader'] = 'WARN'
+node.default['nexus_iq_server']['config']['logging']['loggers']['org.eclipse.jetty'] = 'INFO'
+# WARNING: BasicHttpAuthenticationFilter reveals credentials at DEBUG level
+node.default['nexus_iq_server']['config']['logging']['loggers']['org.apache.shiro.web.filter.authc.BasicHttpAuthenticationFilter'] = 'INFO'
+node.default['nexus_iq_server']['config']['logging']['appenders'] = [
+  {
+    'type' => 'console',
+    'threshold' => 'INFO',
+    'logFormat' => "%d{'yyyy-MM-dd HH:mm:ss,SSSZ'} %level [%thread] %X{username} %logger - %msg%n"
+  },
+  {
+    'type' => 'file',
+    'threshold' => 'ALL',
+    'currentLogFilename' => "/var/log/nexus-iq-server/clm-server.log",
+    'archivedLogFilenamePattern' => "/var/log/nexus-iq-server/clm-server-%d.log.gz",
+    'logFormat' => "%d{'yyyy-MM-dd HH:mm:ss,SSSZ'} %level [%thread] %X{username} %logger - %msg%n",
+    'archivedFileCount' => node['nexus_iq_server']['logging']['archived_file_count']
+  }
+]
+
 config_path = node['nexus_iq_server']['conf_dir'] + '/config.yml'
 start_script = node['nexus_iq_server']['install_dir'] + '/start-nexus-iq-server.sh'
 
@@ -30,6 +70,8 @@ directory node['nexus_iq_server']['config']['sonatypeWork'] do
   action :create
   recursive true
 end
+
+node.override['nexus_iq_server']['logging']['archived_file_count'] = 5
 
 template config_path do
   source 'config.yml.erb'

--- a/recipes/docker.rb
+++ b/recipes/docker.rb
@@ -4,7 +4,8 @@
 #
 # Copyright:: Copyright (c) 2017-present Sonatype, Inc. Apache License, Version 2.0.
 
-node.override['nexus_iq_server']['logging']['archived_file_count'] = 5
+node.default['nexus_iq_server']['config']['server']['requestLog']['appenders'][0]['archivedFileCount'] = 5
+node.default['nexus_iq_server']['config']['logging']['appenders'][1]['archivedFileCount'] = 5
 
 include_recipe 'java'
 include_recipe 'nexus_iq_server::download'

--- a/recipes/docker.rb
+++ b/recipes/docker.rb
@@ -4,6 +4,8 @@
 #
 # Copyright:: Copyright (c) 2017-present Sonatype, Inc. Apache License, Version 2.0.
 
+node.override['nexus_iq_server']['logging']['archived_file_count'] = 5
+
 include_recipe 'java'
 include_recipe 'nexus_iq_server::download'
 include_recipe 'nexus_iq_server::configure'


### PR DESCRIPTION
https://issues.sonatype.org/browse/INT-445

https://help.sonatype.com/display/NXIQM/Updating+your+Nexus+IQ+Server+Configuration

Tested with docker-nexus-iq-server.

The config.yml file now looks like this:

```
#
# Cookbook:: nexus_iq_server
#
# Copyright:: Copyright (c) 2017-present Sonatype, Inc. Apache License, Version 2.0.

---
sonatypeWork: "/sonatype-work"
server:
  applicationConnectors:
  - type: http
    port: 8070
  adminConnectors:
  - type: http
    port: 8071
  requestLog:
    appenders:
    - type: file
      currentLogFilename: "/var/log/nexus-iq-server/request.log"
      archivedLogFilenamePattern: "/var/log/nexus-iq-server/request-%d.log.gz"
      archivedFileCount: 50
logging:
  level: DEBUG
  loggers:
    com.sonatype.insight.scan: INFO
    eu.medsea.mimeutil.MimeUtil2: INFO
    org.apache.http: INFO
    org.apache.http.wire: ERROR
    org.eclipse.birt.report.engine.layout.pdf.font.FontConfigReader: WARN
    org.eclipse.jetty: INFO
    org.apache.shiro.web.filter.authc.BasicHttpAuthenticationFilter: INFO
  appenders:
  - type: console
    threshold: INFO
    logFormat: "%d{'yyyy-MM-dd HH:mm:ss,SSSZ'} %level [%thread] %X{username} %logger
      - %msg%n"
  - type: file
    threshold: ALL
    currentLogFilename: "/var/log/nexus-iq-server/clm-server.log"
    archivedLogFilenamePattern: "/var/log/nexus-iq-server/clm-server-%d.log.gz"
    logFormat: "%d{'yyyy-MM-dd HH:mm:ss,SSSZ'} %level [%thread] %X{username} %logger
      - %msg%n"
    archivedFileCount: 50
```