### PR TITLE
INT - Removed berkshelf install because it is already included in the chefdk

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,7 +63,6 @@ node('ubuntu-chef-zion') {
 
       def gemInstallDirectory = getGemInstallDirectory()
       withEnv(["PATH+GEMS=${gemInstallDirectory}/bin"]) {
-        OsTools.runSafe(this, 'gem install --user-install -v 6.3.2 berkshelf')
         OsTools.runSafe(this, 'berks package')
         dir('build/target') {
           OsTools.runSafe(this, "mv ${WORKSPACE}/cookbooks-*.tar.gz ${archiveName}")


### PR DESCRIPTION
Berkshelf is already included in the chefdk. We were installing berkshelf 6.3.2 which is bringing down a dependency, mixlib-archive 0.4.5, which breaks the build with an "Unrecognized archive format" error: https://github.com/chef/mixlib-archive/issues/20.