### PR TITLE
allow the state of the created systemd unit to be configurable

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,6 +14,8 @@ default['nexus_iq_server']['logs_dir'] = '/var/log/nexus-iq-server'
 default['nexus_iq_server']['conf_dir'] = '/etc/nexus-iq-server'
 default['nexus_iq_server']['java_opts'] = ''
 
+default['nexus_iq_server']['systemd']['actions'] = ['enable', 'start']
+
 #
 # default['nexus_iq_server']['config'] is used to generate config.yml. Parameter names and hierarchy must be the same as they
 # are in config.yml.

--- a/recipes/systemd.rb
+++ b/recipes/systemd.rb
@@ -19,5 +19,5 @@ systemd_unit 'nexus-iq-server.service' do
   [Install]
   WantedBy=multi-user.target
   EOU
-  action [:create, :enable, :start]
+  action [:create] + node['nexus_iq_server']['systemd']['actions'].map(&:to_sym)
 end


### PR DESCRIPTION
While using the cookbook to build an AMI, I'd like the ability to control the status of the created SystemD unit.