### PR TITLE
INT-2560 Add RHCC support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -43,3 +43,9 @@ suites:
 #           x86_64:
 #              url: 'http://10.0.2.2:8080/jdk-8u131-linux-x64.tar.gz'
 #              checksum: '62b215bdfb48bace523723cdbb2157c665e6a25429c73828a32f00e587301236'
+  - name: rh-docker
+    run_list:
+      - recipe[nexus_iq_server::rh-docker]
+    verifier:
+      inspec_tests:
+        - test/smoke/rh-docker

--- a/README.md
+++ b/README.md
@@ -14,7 +14,18 @@ We also provide a `nexus_iq_server::docker` recipe which is exactly the same but
    Installs Nexus IQ Server and starts it as systemd service.
  - nexus_iq_server::docker
    Installs Nexus IQ Server. Instead of a systemd service a startup script `start_nexus_iq_server.sh` is provided in install_dir.
+ - nexus_iq_server::rh-docker
+   Uses the nexus_iq_server:docker recipe but includes additional metadata to conform with Kubernetes
+   and OpenShift standards, a directory with the licenses applicable to the software and a man
+   file for help on how to use the software. It also uses an ENTRYPOINT script to ensure the running
+   user has access to the appropriate permissions for OpenShift 'restricted' SCC.
    
+#### Red Hat help.1
+
+The man file included in the Red Hat image is generated from this [help markdown](files/rh-docker/help.md). Markdown
+can be converted to the appropriate format using [md2roff](https://github.com/nereusx/md2roff). This process is
+currently not part of the automated build and needs to be done manually after any update to the help markdown.
+
 #### Testing
 
 We provide a simple smoke test for this cookbook. Use this command to run it:

--- a/files/rh-docker/help.1
+++ b/files/rh-docker/help.1
@@ -3,7 +3,7 @@
 .BR NEXUS (1)
 Container Image Pages
 % Sonatype
-% December 15, 2017
+% February 2, 2020
 .TH NAME
 .PP
 nexus \- Nexus IQ Server container image

--- a/files/rh-docker/help.1
+++ b/files/rh-docker/help.1
@@ -1,0 +1,74 @@
+.PP
+%
+.BR NEXUS (1)
+Container Image Pages
+% Sonatype
+% December 15, 2017
+.TH NAME
+.PP
+nexus \- Nexus IQ Server container image
+.SH DESCRIPTION
+.PP
+The nexus iq server image provides a containerized packaging of the Nexus IQ Server.
+Nexus IQ Server  is a policy engine powered by precise intelligence on open source components. It provides a number of tools to improve component usage in your software supply chain, allowing you to automate your processes and achieve accelerated speed to delivery while also increasing product quality.
+.PP
+The nexus iq server image is designed to be run by the atomic command with one of these options:
+.PP
+\fB\fCrun\fR
+.PP
+Starts the installed container with selected privileges to the host.
+.PP
+\fB\fCstop\fR
+.PP
+Stops the installed container
+.PP
+The container itself consists of:
+    \- Linux base image
+    \- Oracle Java JDK
+    \- Nexus IQ Server
+    \- Atomic help file
+.PP
+Files added to the container during docker build include: /help.1.
+.SH USAGE
+.PP
+To use the nexus iq server container, you can run the atomic command with run, stop, or uninstall options:
+.PP
+To run the nexus iq server container:
+.IP
+atomic run nexus-iq-server
+.PP
+To stop the nexus iq server container (after it is installed), run:
+.IP
+atomic stop nexus-iq-server
+.SH LABELS
+.PP
+The nexus iq server container includes the following LABEL settings:
+.PP
+That atomic command runs the docker command set in this label:
+.PP
+\fB\fCRUN=\fR
+.IP
+LABEL RUN='docker run \-d \-p 8071:8071 \-\-name ${NAME} ${IMAGE}'
+.IP
+The contents of the RUN label tells an \fB\fCatomic run nexus-iq-server\fR command to open port 8071 & set the name of the container.
+.PP
+\fB\fCSTOP=\fR
+.IP
+LABEL STOP='docker stop ${NAME}'
+.PP
+\fB\fCName=\fR
+.PP
+The registry location and name of the image. For example, Name="Nexus IQ Server".
+.PP
+\fB\fCVersion=\fR
+.PP
+The Nexus IQ Server version from which the container was built. For example, Version="1.84.0\-01".
+.PP
+When the atomic command runs the nexus container, it reads the command line associated with the selected option
+from a LABEL set within the Docker container itself. It then runs that command. The following sections detail
+each option and associated LABEL:
+.SH SECURITY IMPLICATIONS
+.PP
+\fB\fC\-d\fR
+.PP
+Runs continuously as a daemon process in the background

--- a/files/rh-docker/help.1
+++ b/files/rh-docker/help.1
@@ -6,7 +6,7 @@ Container Image Pages
 % February 2, 2020
 .TH NAME
 .PP
-nexus \- Nexus IQ Server container image
+nexus-iq-server \- Nexus IQ Server container image
 .SH DESCRIPTION
 .PP
 The nexus iq server image provides a containerized packaging of the Nexus IQ Server.

--- a/files/rh-docker/help.md
+++ b/files/rh-docker/help.md
@@ -1,6 +1,6 @@
 % NEXUS(1) Container Image Pages
 % Sonatype
-% December 15, 2017
+% February 2, 2020
 
 # NAME
 nexus \- Nexus IQ Server container image

--- a/files/rh-docker/help.md
+++ b/files/rh-docker/help.md
@@ -3,7 +3,7 @@
 % February 2, 2020
 
 # NAME
-nexus \- Nexus IQ Server container image
+nexus-iq-server \- Nexus IQ Server container image
 
 # DESCRIPTION
 The nexus iq server image provides a containerized packaging of the Nexus IQ Server.

--- a/files/rh-docker/help.md
+++ b/files/rh-docker/help.md
@@ -1,0 +1,72 @@
+% NEXUS(1) Container Image Pages
+% Sonatype
+% December 15, 2017
+
+# NAME
+nexus \- Nexus IQ Server container image
+
+# DESCRIPTION
+The nexus iq server image provides a containerized packaging of the Nexus IQ Server.
+Nexus IQ Server  is a policy engine powered by precise intelligence on open source components. It provides a number of tools to improve component usage in your software supply chain, allowing you to automate your processes and achieve accelerated speed to delivery while also increasing product quality.
+
+The nexus iq server image is designed to be run by the atomic command with one of these options:
+
+`run`
+
+Starts the installed container with selected privileges to the host.
+
+`stop`
+
+Stops the installed container
+
+The container itself consists of:
+    - Linux base image
+    - Oracle Java JDK
+    - Nexus IQ Server
+    - Atomic help file
+
+Files added to the container during docker build include: /help.1.
+
+# USAGE
+To use the nexus iq server container, you can run the atomic command with run, stop, or uninstall options:
+
+To run the nexus iq server container:
+
+  atomic run nexus-iq-server
+
+To stop the nexus iq server container (after it is installed), run:
+
+  atomic stop nexus-iq-server
+
+# LABELS
+The nexus iq server container includes the following LABEL settings:
+
+That atomic command runs the docker command set in this label:
+
+`RUN=`
+
+  LABEL RUN='docker run -d -p 8071:8071 --name ${NAME} ${IMAGE}'
+
+  The contents of the RUN label tells an `atomic run nexus-iq-server` command to open port 8071 & set the name of the container.
+
+`STOP=`
+
+  LABEL STOP='docker stop ${NAME}'
+
+`Name=`
+
+The registry location and name of the image. For example, Name="Nexus IQ Server".
+
+`Version=`
+
+The Nexus IQ Server version from which the container was built. For example, Version="1.84.0-01".
+
+When the atomic command runs the nexus container, it reads the command line associated with the selected option
+from a LABEL set within the Docker container itself. It then runs that command. The following sections detail
+each option and associated LABEL:
+
+# SECURITY IMPLICATIONS
+
+`-d`
+
+Runs continuously as a daemon process in the background

--- a/files/rh-docker/licenses/LICENSE
+++ b/files/rh-docker/licenses/LICENSE
@@ -1,0 +1,10 @@
+Sonatype Nexus (TM) Open Source Version
+Copyright (c) 2008-present Sonatype, Inc.
+All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+
+This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+
+Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+Eclipse Foundation. All other trademarks are the property of their respective owners.

--- a/files/rh-docker/uid_entrypoint.sh
+++ b/files/rh-docker/uid_entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+#
+# Copyright:: Copyright (c) 2017-present Sonatype, Inc. Apache License, Version 2.0.
+#
+# arbitrary uid recognition at runtime - for OpenShift deployments
+USER_ID=$(id -u)
+if [[ ${USER_UID} != ${USER_ID} ]]; then
+    sed "s@${USER_NAME}:x:\${USER_ID}:@${USER_NAME}:x:${USER_ID}:@g" /etc/passwd.template > /etc/passwd
+fi
+exec "$@"

--- a/files/rh-docker/uid_template.sh
+++ b/files/rh-docker/uid_template.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+#
+# Copyright:: Copyright (c) 2017-present Sonatype, Inc. Apache License, Version 2.0.
+#
+# arbitrary uid recognition at runtime - for OpenShift deployments
+sed "s@${USER_NAME}:x:${USER_UID}:@${USER_NAME}:x:\${USER_ID}:@g" /etc/passwd > /etc/passwd.template

--- a/recipes/rh-docker.rb
+++ b/recipes/rh-docker.rb
@@ -1,0 +1,48 @@
+#
+# Cookbook:: nexus_iq_server
+# Recipe:: rh-docker
+#
+# Copyright:: Copyright (c) 2017-present Sonatype, Inc. Apache License, Version 2.0.
+
+if node['platform'] == 'rhel'
+  default['yum']['rhel-7-server-rpms']['enabled'] = true
+  default['yum']['rhel-7-server-rpms']['managed'] = true
+  default['yum']['rhel-7-server-optional-rpms']['enabled'] = true
+  default['yum']['rhel-7-server-optional-rpms']['managed'] = true
+  default['yum']['rhel-7-server-thirdparty-oracle-java-rpms']['enabled'] = true
+  default['yum']['rhel-7-server-thirdparty-oracle-java-rpms']['managed'] = true
+end
+
+include_recipe 'nexus_iq_server::docker'
+
+group 'root' do
+  action :modify
+  members 'nexus'
+  append true
+end
+
+directory '/licenses/' do
+  owner 'root'
+  group 'root'
+  mode '755'
+  action :create
+end
+
+[ 'help.1', 'uid_template.sh', 'uid_entrypoint.sh', 'licenses/LICENSE' ].each do | file |
+  cookbook_file "/#{file}" do
+    source "rh-docker/#{file}"
+    owner 'root'
+    group 'root'
+    mode '755'
+  end
+end
+
+bash 'uid_template.sh' do
+  code <<-EOH
+    /uid_template.sh
+  EOH
+end
+
+file '/etc/passwd' do
+  mode '664'
+end

--- a/test/smoke/rh-docker/perm_test.rb
+++ b/test/smoke/rh-docker/perm_test.rb
@@ -1,0 +1,25 @@
+#
+# Cookbook:: nexus_iq_server
+#
+# Copyright:: Copyright (c) 2017-present Sonatype, Inc. Apache License, Version 2.0.
+#
+
+# Permissions test for recipe nexus_iq_server::rh-docker
+
+control 'rh-docker-perms-test-001' do
+  title 'Allows nexus user to mutate /etc/password'
+  describe user('nexus') do
+    it { should exist }
+  end
+
+  describe file('/etc/passwd') do
+    it { should be_allowed('write', by_user: 'nexus') }
+  end
+end
+
+control 'rh-docker-perms-test-002' do
+ title 'Creates a template for passwd'
+  describe file('/etc/passwd.template') do
+    it { should exist }
+  end
+end

--- a/test/smoke/rh-docker/perm_test.rb
+++ b/test/smoke/rh-docker/perm_test.rb
@@ -7,7 +7,7 @@
 # Permissions test for recipe nexus_iq_server::rh-docker
 
 control 'rh-docker-perms-test-001' do
-  title 'Allows nexus user to mutate /etc/password'
+  title 'Allows nexus user to mutate system password file'
   describe user('nexus') do
     it { should exist }
   end

--- a/test/smoke/rh-docker/rh_requirements_test.rb
+++ b/test/smoke/rh-docker/rh_requirements_test.rb
@@ -1,0 +1,18 @@
+#
+# Cookbook:: nexus_iq_server
+#
+# Copyright:: Copyright (c) 2017-present Sonatype, Inc. Apache License, Version 2.0.
+#
+
+# Red Hat requirements test for recipe nexus_iq_server::rh-docker
+
+control 'rh-docker-requirements-test-001' do
+  title 'Includes the required files for Red Hat certification'
+  describe file('/help.1') do
+    it { should exist }
+  end
+
+  describe file('/licenses/LICENSE') do
+    it { should exist }
+  end
+end


### PR DESCRIPTION
Jira: https://issues.sonatype.org/browse/INT-2560
Build: https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/chef-nexus-iq-server-feature/job/INT-2560-create-RHCC/

Adds Red Hat Certified Container support